### PR TITLE
SCE-8 Replace border by outlines

### DIFF
--- a/content-script/index.js
+++ b/content-script/index.js
@@ -2,12 +2,12 @@ const elementWithListener = [];
 
 const addElementBorder = (event) => {
   const element = event.target;
-  element.style.border = "2px solid black";
+  element.style.outline = "2px solid black";
 };
 
 const removeElementBorder = (event) => {
   const element = event.target;
-  element.style.border = "none";
+  element.style.outline = "none";
 };
 
 const handleElementBorder = ({ target }) => {


### PR DESCRIPTION
To avoid layout shift, replace border by outline property on overed elements.